### PR TITLE
Load functions into repl context with for-in loop not R.functions()

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = function() {
 	for (var key in R){
         repl.context[key] = R[key];
     }
-
+    
 	var F = repl.context.fantasy =  require('ramda-fantasy');
 
 	R.map(function(f){repl.context[f] = F[f]},R.keys(F))

--- a/index.js
+++ b/index.js
@@ -11,9 +11,9 @@ module.exports = function() {
 	var R = repl.context.R = require('ramda');
 
 	for (var key in R){
-        repl.context[key] = R[key];
-    }
-    
+        	repl.context[key] = R[key];
+    	}
+    	
 	var F = repl.context.fantasy =  require('ramda-fantasy');
 
 	R.map(function(f){repl.context[f] = F[f]},R.keys(F))

--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ module.exports = function() {
 	var R = repl.context.R = require('ramda');
 
 	for (var key in R){
-          repl.context[key] = R[key];
-    	}
+	  repl.context[key] = R[key];
+	}
     	
 	var F = repl.context.fantasy =  require('ramda-fantasy');
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function() {
 	var R = repl.context.R = require('ramda');
 
 	for (var key in R){
-        	repl.context[key] = R[key];
+          repl.context[key] = R[key];
     	}
     	
 	var F = repl.context.fantasy =  require('ramda-fantasy');

--- a/index.js
+++ b/index.js
@@ -10,9 +10,9 @@ module.exports = function() {
 
 	var R = repl.context.R = require('ramda');
 
-	R.functions(R).forEach(function(f) {
-	  repl.context[f] = R[f];
-	});
+	for (var key in R){
+        repl.context[key] = R[key];
+    }
 
 	var F = repl.context.fantasy =  require('ramda-fantasy');
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = function() {
 	for (var key in R){
 	  repl.context[key] = R[key];
 	}
-	
+
 	var F = repl.context.fantasy =  require('ramda-fantasy');
 
 	R.map(function(f){repl.context[f] = F[f]},R.keys(F))

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = function() {
 	for (var key in R){
 	  repl.context[key] = R[key];
 	}
-    	
+	
 	var F = repl.context.fantasy =  require('ramda-fantasy');
 
 	R.map(function(f){repl.context[f] = F[f]},R.keys(F))


### PR DESCRIPTION
Looks like in Ramda v0.19.0, R.functions() is no longer defined, so the call to R.functions in index.js was throwing this error: "R.functions is not a function". I swapped the forEach with a for-in loop which loops through each key in the object exported by the Ramda v0.19.0 module and inserts it into the repl context. 
